### PR TITLE
Fix normal map for black and white theme

### DIFF
--- a/Parts/container6/part.cfg
+++ b/Parts/container6/part.cfg
@@ -63,7 +63,7 @@ PART
 			TEXTURE
 			{
 				mainTextureURL = KIS/Parts/container6/kis_micro_bw_c
-				_BumpMap = = KIS/Parts/container6/kis_mini_n
+				_BumpMap = KIS/Parts/container6/kis_mini_n
 				shader = KSP/Bumped Specular
 			}
 		}


### PR DESCRIPTION
Remove extra "=" that broke the normal for the black and white theme of the part.